### PR TITLE
Added override support for description and longDescription when !link…

### DIFF
--- a/csdl_creator.py
+++ b/csdl_creator.py
@@ -256,6 +256,10 @@ class CsdlFile:
             if "link" in descriptors:
                 kwargs = {}
                 kwargs['schema_name'] = descriptors['link']
+                if 'description' in descriptors:
+                    kwargs['description'] = descriptors['description']
+                if 'longDescription' in descriptors:
+                    kwargs['longDescription'] = descriptors['longDescription']
                 if not any([descriptors['link'] in x.attrib.get('Uri', '').split('/')[-1] for x in self.main_csdl]):
                     my_node = xml_convenience.add_reference(None, None, descriptors['link'])
                     self.main_csdl.insert(3, my_node)


### PR DESCRIPTION
… annotation is used.
The behavior was already present in the create_navigation() function, however, the calling function did not initialize the values passed for the description and/or longDescription arguments.  As a result of this, the default description and longDescription text was always used for the newly created navigation.  This small modification updates the code which calls create_navigation() so that the description and longDescription parameters are properly initialized. 